### PR TITLE
Make the list of reporters configurable with reporters options

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ newman-run -f <./feed/<feed_file.json> -c <./collection/<example_collection.json
 This allows us to run any collection dynamically along with our set of collections.
 
 The above will take care the reporting part and we don't need to mention about that from the command line. Along with allure reports, newman's default CLI, HTML, HTMLEXTRA and JSON reports are added which can be found at `reports/` path. For sophesticated classification, reports for each collection is isolated with different name. If needed JSON and HTML files can be pushed to S3 for further processing or to have a record.
+You can configure the list of reporters to use:
+
+```
+newman-run -f <./feed/<feed_file.json> -R cli html htmlextra json allure
+```
 
 ### Remove previous run report files
 

--- a/bin/newman-run.js
+++ b/bin/newman-run.js
@@ -30,11 +30,12 @@ const yargs = require("yargs");
 			.option("e", { alias: "environment", describe: "Environment file path", type: "string"})
 			.option("s", { alias: "synchronous", describe: "Run collections in sync way. Async by default", type: "string"})
 			.option("r", { alias: "remove", describe: "To remove the files from reporting directory"})
+			.option("R", { alias: "reporters", describe: "To override reporters list", type: "array"})
 			.option("v", { alias: "version", describe: "Current version for the newman-run package"})
 			.check(argv => { if(argv.f == undefined && argv.c == undefined && argv.r == undefined) { console.log(file_error_message); return false } else { return true }})
 			.argv
 
-	const NC = new NewmanConfig()
+	const NC = new NewmanConfig(options.reporters)
 
 	if (options.remove) {
 		NC.clearResultsFolder()

--- a/lib/core.js
+++ b/lib/core.js
@@ -6,16 +6,16 @@ const rimraf = require('rimraf');
 
 class NewmanConfig {
 
-    constructor() {
-        this.current_path = path.dirname(fs.realpathSync(__filename))
-        this.reporters_list = ['cli', 'json', 'html', 'allure', 'htmlextra']
-        this.allure_report_path = './reports/allure'
-        this.newman_json_report_path = './reports/json/'
-        this.newman_html_report_path = './reports/html/'
-		this.newman_htmlextra_report_path = './reports/htmlextra/'
+    constructor(reporters) {
+      this.current_path = path.dirname(fs.realpathSync(__filename))
+      this.reporters_list = reporters || ['cli', 'json', 'html', 'allure', 'htmlextra']
+      this.allure_report_path = './reports/allure'
+      this.newman_json_report_path = './reports/json/'
+      this.newman_html_report_path = './reports/html/'
+      this.newman_htmlextra_report_path = './reports/htmlextra/'
     }
 
-    async loopRun(root_json_file, sync = false) {
+  async loopRun(root_json_file, sync = false) {
 		return (async () => {
 			console.log('Feed file taken is: ' + root_json_file);
 			if (`${root_json_file}`.includes('\\')) {
@@ -37,42 +37,45 @@ class NewmanConfig {
 				} catch(e) {
 					if(e.err != undefined)
 						console.error(e.err);
-					//process.exit(1);
 				}
 				console.log("!-------------------------------------------------------------------------------------------!")
 			}
 
 		})();
-    }
+  }
 
     runCollection(collection, environment = undefined) {
-		// call newman.run to pass `options` object and wait for callback
-		console.log('Collection file taken to run: ' + collection);
-		if(environment != undefined) {
-			console.log('Environment file taken to run: ' + environment);
-			environment = this.getRelativePath(environment);
-		}
-		if (`${collection}`.includes('\\')) {
-			console.log('newman-run is supported only in mac and linux environments, please try to use the package directly in a CI environment by mentioning the file path in linux format.')
-			return -1;
-			//process.exit(1);
-		}
-		var file_name = collection.split("/")
-        collection = this.getRelativePath(collection)
+      // call newman.run to pass `options` object and wait for callback
+      console.log("Collection file taken to run: " + collection);
+      if (environment != undefined) {
+        console.log("Environment file taken to run: " + environment);
+        environment = this.getRelativePath(environment);
+      }
+      if (`${collection}`.includes("\\")) {
+        console.log(
+          "newman-run is supported only in mac and linux environments, please try to use the package directly in a CI environment by mentioning the file path in linux format."
+        );
+        return -1;
+      }
+      var file_name = collection.split("/");
+      collection = this.getRelativePath(collection);
 
-		newman.run(this.getNewmanRunOptions(collection, environment, file_name), function(err, summary) { 
-            if (err || summary.run.error || summary.run.failures.length) {
-				console.log('collection run complete with errors...');
-				console.log("err", err);
-				console.log("summary.run.error", summary.run.error);
-				console.log("summary.run.failures.length", summary.run.failures.length);
-            } else {
-				console.log('collection run complete!');
-			}
-        });
+      newman.run(
+        this.getNewmanRunOptions(collection, environment, file_name),
+        function (err, summary) {
+          if (err || summary.run.error || summary.run.failures.length) {
+            console.log("collection run complete with errors...");
+            console.log("err", err);
+            console.log("summary.run.error", summary.run.error);
+            console.log("summary.run.failures.length", summary.run.failures.length);
+          } else {
+            console.log("collection run complete!");
+          }
+        }
+      );
     }
 
-    async runCollectionSync(collection, environment = undefined) {
+  async runCollectionSync(collection, environment = undefined) {
 		return new Promise((resolve, reject) => {
 			// call newman.run to pass `options` object and wait for callback
 			console.log('Collection file taken to run: ' + collection);
@@ -83,7 +86,6 @@ class NewmanConfig {
 			if (`${collection}`.includes('\\')) {
 				console.log('newman-run is supported only in mac and linux environments, please try to use the package directly in a CI environment by mentioning the file path in linux format.')
 				reject(1);
-				//process.exit(1);
 			}
 
 			var file_name = collection.split("/");
@@ -107,12 +109,11 @@ class NewmanConfig {
 				}
 			});
 		});
-    }
+  }
 
 	getNewmanRunOptions(collection, environment, file_name) {
 		let opt = {
 			collection: require(collection),
-			//environment: require(environment),
 			reporters: this.reporters_list,
 			reporter: {
 				html: {


### PR DESCRIPTION
This will allow the configuration of the list of reporters.
By default the current list of reporters is used. By passing the -R or -reporters options, the user can overwrite the list of reporters. 